### PR TITLE
KCT-255.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # libgtrfc3161 #
-Guardtime Keyless Signature Infrastructure (KSI) is an industrial scale blockchain platform that cryptographically
-ensures data integrity and proves time of existence. Its keyless signatures, based on hash chains, link data to global
-calendar blockchain. The checkpoints of the blockchain, published in newspapers and electronic media, enable long term
-integrity of any digital asset without the need to trust any system. There are many applications for KSI, a classical
-example is signing of any type of logs - system logs, financial transactions, call records, etc. For more,
-see [https://guardtime.com](https://guardtime.com).
+Guardtime's KSI Blockchain is an industrial scale blockchain platform that
+cryptographically ensures data integrity and proves time of existence.
+The KSI signatures, based on hash chains, link data to this global calendar
+blockchain. The checkpoints of the blockchain, published in newspapers and
+electronic media, enable long term integrity of any digital asset without the
+need to trust any system.
+There are many applications for KSI, a classical example is signing of any type
+of logs - system logs, financial transactions, call records, etc.
+For more, see [https://guardtime.com](https://guardtime.com).
 
-`libgtrfc3161` is a software development kit for developers who want to convert Guardtime's legacy signatures to
-Guardtime's KSI signatures in their C/C++ based applications .
+`libgtrfc3161` is a software development kit for developers who want to convert
+Guardtime's legacy signatures to Guardtime's KSI signatures in their
+C/C++ based applications .
 
 ## Installation ##
 
 ### Latest Release from Guardtime Repository
 
-In order to install the `libgtrfc3161` CentOS/RHEL packages directly from the Guardtime public repository, download and save the repository configuration to the `/etc/yum.repos.d/` folder:
+In order to install the `libgtrfc3161` CentOS/RHEL packages directly from
+the Guardtime public repository, download and save the repository configuration
+to the `/etc/yum.repos.d/` folder:
 
 ```
 cd /etc/yum.repos.d
@@ -29,9 +35,16 @@ yum install libgtrfc3161
 
 ### From Source Code
 
-If the latest version is needed or the package is not available for the platform you are using, check out the source code from Github and build it with the `rebuild.sh` script. To build the legacy signature converter SDK, `libksi` and `libksi-devel` (KSI C SDK) packages are needed. `libksi` is available in Guardtime repository or as source code in GitHub: [https://github.com/GuardTime/libksi](https://github.com/GuardTime/libksi).
+If the latest version is needed or the package is not available for the platform
+you are using, check out the source code from Github and build it with
+the `rebuild.sh` script.
+To build the legacy signature converter SDK, `libksi` and `libksi-devel`
+(KSI C SDK) packages are needed. `libksi` is available in Guardtime repository
+or as source code in GitHub:
+[https://github.com/GuardTime/libksi](https://github.com/GuardTime/libksi).
 
-To use libgtrfc3161 in your C/C++ project, link it against the `libksi` and `libgtrfc3161` libraries.
+To use `libgtrfc3161` in your C/C++ project, link it against the `libksi`
+and `libgtrfc3161` libraries.
 
 ## Usage ##
 
@@ -73,7 +86,8 @@ A simple example how to convert a legacy signature:
   KSI_CTX_free(ctx);
 ```
 
-The API full reference is available here [http://guardtime.github.io/libgtrfc3161/](http://guardtime.github.io/libgtrfc3161/).
+The API full reference is available here:
+[http://guardtime.github.io/libgtrfc3161/](http://guardtime.github.io/libgtrfc3161/).
 
 ## Contributing ##
 
@@ -84,13 +98,13 @@ See CONTRIBUTING.md file.
 See LICENSE file.
 
 ## Dependencies ##
-| Dependency        | Version                           | License type | Source                         | Notes |
-| :---              | :---                              | :---         | :---                           |:---   |
-| libksi            | >= 3.10 | Apache 2.0   | https://github.com/GuardTime/libksi       |  |
-| CuTest            | 1.5                               | Zlib         |                                | Required only for testing. |
+| Dependency | Version | License type | Source                              | Notes                      |
+|:-----------|:--------|:-------------|:------------------------------------|:---------------------------|
+| libksi     | >= 3.10 | Apache 2.0   | https://github.com/GuardTime/libksi |                            |
+| CuTest     | 1.5     | Zlib         |                                     | Required only for testing. |
 
 ## Compatibility ##
-| OS / Platform                              | Compatibility                                |
-| :---                                       | :---                                         |
-| CentOS / RHEL 6 and 7, x86_64 architecture | Fully compatible and tested.                  |
-| Debian, ...                                | Compatible but not tested on a regular basis. |
+| OS/Platform                 | Compatibility                                 |
+|:----------------------------|:----------------------------------------------|
+| CentOS/RHEL 6 and 7, x86_64 | Fully compatible and tested.                  |
+| Debian, ...                 | Compatible but not tested on a regular basis. |


### PR DESCRIPTION
Changed Keyless Signature Infrastructure to KSI Blockchain as of
https://guardtime.atlassian.net/browse/KCT-255
and
https://guardtime.atlassian.net/browse/KCT-248